### PR TITLE
Add npm package validate-color to validate user-provided colors; add conditionals to account for edge cases.

### DIFF
--- a/Develop/index.js
+++ b/Develop/index.js
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const inquirer = require('inquirer');
+const validateColor = require('validate-color').default;
 
 // shapes.js will export Triangle, Circle, and Square classes.
 const generateSvg = require('../Develop/lib/shapes.js');
@@ -13,7 +14,7 @@ const questions = [
     {
         type: "input", 
         name: "textColor", 
-        message: "2. Please enter the color for your logo's text, as either a color keyword or a hexadecimal number."
+        message: "2. Please enter the color for your logo's text, as either: a color keyword or a hexadecimal number beginning in #."
     }, 
     {
         type: "list", 
@@ -24,10 +25,9 @@ const questions = [
     {
         type: "input", 
         name: "shapeColor", 
-        message: "4. Please enter the fill color for the shape, as either a color keyword or a hexadecimal number."
+        message: "4. Please enter the fill color for the shape, as either: a color keyword or a hexadecimal number beginning in #."
     }
 ];
-
 
 function init() {
     inquirer
@@ -35,14 +35,27 @@ function init() {
 
         .then((answers) => {
             console.log(answers);
-            
-            let svgCode = generateSvg(answers);
+            // validTextColor will be true if the textColor is valid, or false if the textColor is invalid.
+            let validTextColor = validateColor(answers.textColor);
+            console.log(validTextColor);
+            // validShapeColor will be true if the shapeColor is valid, or false if the shapeColor is invalid.
+            let validShapeColor = validateColor(answers.shapeColor);
+            console.log(validShapeColor);
 
-            writeToFile("logo.svg", svgCode);
+            if (answers.textForShape.length > 3 || answers.textForShape.length == 0 || !validTextColor || !validShapeColor) {
+                throw new Error("Check your responses--you either provided an invalid amount of characters for your logo text, or an invalid color for your text color or shape color.")
+            }
+
+            if (answers.textForShape && answers.textColor && answers.shape && answers.shapeColor) {
+                let svgCode = generateSvg(answers);
+                writeToFile("logo.svg", svgCode);
+            } else {
+                throw new Error("There was an error in obtaining your responses--please try again.")
+            }
         })
         .catch((error) => {
             if (error.isTtyError) {
-                throw new Error(`Prompt couldn't be rendered in current environment`);
+                throw new Error("Prompt couldn't be rendered in current environment");
                 } else {
                 // If the error is not a Tty error, the error will appear in a console log in red.
                 console.error(error);

--- a/Develop/lib/shapes.js
+++ b/Develop/lib/shapes.js
@@ -60,6 +60,7 @@ function generateSvg(answers) {
     if (answers.shape == "circle") {
         const circle = new Circle(answers.textForShape, answers.textColor, answers.shape, answers.shapeColor);
         return circle.render();
+        // Brainstorming a way we could handle any potential errors here: what if we get a circle that was rendered incorrectly somehow, eg we somehow got a circle that had different values than the user requested?
     } else if (answers.shape == "triangle") {
         const triangle = new Triangle(answers.textForShape, answers.textColor, answers.shape, answers.shapeColor);
         return triangle.render();

--- a/Develop/logo.svg
+++ b/Develop/logo.svg
@@ -1,7 +1,7 @@
 <svg version="1.1" width="300" height="200" xmlns="http://www.w3.org/2000/svg">
 
-<rect width="160" height="160" x="60" y="20" rx="2" ry="2" fill="#00ff00" />
+<rect width="160" height="160" x="60" y="20" rx="2" ry="2" fill="green" />
       
-<text x="140" y="120" font-size="60" text-anchor="middle" fill="#ff0000">RTY</text>
+<text x="140" y="120" font-size="60" text-anchor="middle" fill="yellow">EDG</text>
       
 </svg>

--- a/Develop/package-lock.json
+++ b/Develop/package-lock.json
@@ -12,7 +12,8 @@
         "inquirer": "^8.2.4"
       },
       "devDependencies": {
-        "jest": "^29.7.0"
+        "jest": "^29.7.0",
+        "validate-color": "^2.2.4"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -3838,6 +3839,12 @@
       "engines": {
         "node": ">=10.12.0"
       }
+    },
+    "node_modules/validate-color": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/validate-color/-/validate-color-2.2.4.tgz",
+      "integrity": "sha512-Znolz+b6CwW6eBXYld7MFM3O7funcdyRfjKC/X9hqYV/0VcC5LB/L45mff7m3dIn9wdGdNOAQ/fybNuD5P/HDw==",
+      "dev": true
     },
     "node_modules/walker": {
       "version": "1.0.8",

--- a/Develop/package.json
+++ b/Develop/package.json
@@ -17,6 +17,7 @@
     "inquirer": "^8.2.4"
   },
   "devDependencies": {
-    "jest": "^29.7.0"
+    "jest": "^29.7.0",
+    "validate-color": "^2.2.4"
   }
 }

--- a/Develop/practice-generated-square.svg
+++ b/Develop/practice-generated-square.svg
@@ -1,6 +1,6 @@
 <svg version="1.1" width="300" height="200" xmlns="http://www.w3.org/2000/svg">
 
-<rect width="160" height="160" x="60" y="20" rx="2" ry="2" fill="#000000" />
+<rect width="160" height="160" x="60" y="20" rx="2" ry="2" fill="#ff00ff" />
       
 <text x="140" y="120" font-size="60" text-anchor="middle" fill="#ffffff">YLP</text>
       


### PR DESCRIPTION
Add npm package validate-color to assist with validating colors from user input. Add conditionals to account for invalid or missing user input.